### PR TITLE
Fix COM interop issues: use undefined instead of null for optional parameters

### DIFF
--- a/src/adapters/winax-adapter-enhanced.ts
+++ b/src/adapters/winax-adapter-enhanced.ts
@@ -324,7 +324,7 @@ export class EnhancedWinAxAdapter implements ISolidWorksAdapter {
       // Select profiles
       for (const profile of params.profiles) {
         this.currentModel.Extension.SelectByID2(
-          profile, 'SKETCH', 0, 0, 0, true, 0, null, 0
+          profile, 'SKETCH', 0, 0, 0, true, 0, undefined, 0
         );
       }
       
@@ -390,12 +390,31 @@ export class EnhancedWinAxAdapter implements ISolidWorksAdapter {
   // Helper Methods
   
   private selectSketchForFeature(): boolean {
+    // Method 1: Feature tree traversal (most reliable, avoids SelectByID2 COM issues)
+    try {
+      const featureCount = this.currentModel.GetFeatureCount();
+      for (let i = 0; i < Math.min(10, featureCount); i++) {
+        const feat = this.currentModel.FeatureByPositionReverse(i);
+        if (feat) {
+          const typeName = feat.GetTypeName2();
+          if (typeName && (typeName === 'ProfileFeature' || typeName.toLowerCase().includes('sketch'))) {
+            feat.Select2(false, 0);
+            logger.info(`Selected sketch by feature tree: ${feat.Name || feat.GetName()}`);
+            return true;
+          }
+        }
+      }
+    } catch (e) {
+      logger.warn(`Feature tree search failed: ${e}`);
+    }
+
+    // Method 2: SelectByID2 with undefined Callout (not null, to avoid VT_NULL type mismatch)
     const ext = this.currentModel.Extension;
     const sketchNames = ['Sketch1', 'Sketch2', 'Sketch3', 'Sketch4', 'Sketch5'];
-    
+
     for (const name of sketchNames) {
       try {
-        const selected = ext.SelectByID2(name, 'SKETCH', 0, 0, 0, false, 0, null, 0);
+        const selected = ext.SelectByID2(name, 'SKETCH', 0, 0, 0, false, 0, undefined, 0);
         if (selected) {
           logger.info(`Selected sketch: ${name}`);
           return true;
@@ -404,7 +423,7 @@ export class EnhancedWinAxAdapter implements ISolidWorksAdapter {
         // Try next
       }
     }
-    
+
     return false;
   }
   
@@ -563,7 +582,7 @@ export class EnhancedWinAxAdapter implements ISolidWorksAdapter {
     if (!this.currentModel) throw new Error('No active model');
     
     const ext = this.currentModel.Extension;
-    ext.SelectByID2(plane + ' Plane', 'PLANE', 0, 0, 0, false, 0, null, 0);
+    ext.SelectByID2(plane + ' Plane', 'PLANE', 0, 0, 0, false, 0, undefined, 0);
     this.currentModel.SketchManager.InsertSketch(true);
     
     return this.currentModel.SketchManager.ActiveSketch.Name;

--- a/src/adapters/winax-adapter.ts
+++ b/src/adapters/winax-adapter.ts
@@ -529,12 +529,31 @@ export class WinAxAdapter implements ISolidWorksAdapter {
   }
   
   private selectSketchForExtrusion(): boolean {
+    // Method 1: Feature tree traversal (most reliable, avoids SelectByID2 COM issues)
+    try {
+      const featureCount = this.currentModel.GetFeatureCount();
+      for (let i = 0; i < Math.min(10, featureCount); i++) {
+        const feat = this.currentModel.FeatureByPositionReverse(i);
+        if (feat) {
+          const typeName = feat.GetTypeName2();
+          if (typeName && (typeName === 'ProfileFeature' || typeName.toLowerCase().includes('sketch'))) {
+            feat.Select2(false, 0);
+            logger.info(`Selected sketch by feature tree: ${feat.Name || feat.GetName()}`);
+            return true;
+          }
+        }
+      }
+    } catch (e) {
+      logger.warn(`Feature tree search failed: ${e}`);
+    }
+
+    // Method 2: SelectByID2 with undefined Callout (not null, to avoid VT_NULL type mismatch)
     const ext = this.currentModel.Extension;
     const sketchNames = ['Sketch1', 'Sketch2', 'Sketch3', 'Sketch4', 'Sketch5'];
-    
+
     for (const name of sketchNames) {
       try {
-        const selected = ext.SelectByID2(name, 'SKETCH', 0, 0, 0, false, 0, null, 0);
+        const selected = ext.SelectByID2(name, 'SKETCH', 0, 0, 0, false, 0, undefined, 0);
         if (selected) {
           logger.info(`Selected sketch: ${name}`);
           return true;
@@ -543,24 +562,7 @@ export class WinAxAdapter implements ISolidWorksAdapter {
         // Try next name
       }
     }
-    
-    // Try to select the last sketch feature
-    try {
-      const featureCount = this.currentModel.GetFeatureCount();
-      for (let i = 0; i < Math.min(10, featureCount); i++) {
-        const feat = this.currentModel.FeatureByPositionReverse(i);
-        if (feat) {
-          const typeName = feat.GetTypeName2();
-          if (typeName && typeName.toLowerCase().includes('sketch')) {
-            feat.Select2(false, 0);
-            return true;
-          }
-        }
-      }
-    } catch (e) {
-      // Failed to select sketch
-    }
-    
+
     return false;
   }
   
@@ -635,7 +637,7 @@ export class WinAxAdapter implements ISolidWorksAdapter {
     const ext = this.currentModel.Extension;
     
     // Select the plane
-    const selected = ext.SelectByID2(plane, 'PLANE', 0, 0, 0, false, 0, null, 0);
+    const selected = ext.SelectByID2(plane, 'PLANE', 0, 0, 0, false, 0, undefined, 0);
     if (!selected) {
       throw new Error(`Failed to select plane: ${plane}`);
     }

--- a/src/solidworks/api.ts
+++ b/src/solidworks/api.ts
@@ -240,50 +240,51 @@ export class SolidWorksAPI {
       let selectedSketchName = '';
       const attemptedSketches: string[] = [];
 
-      // Method 1: Try to select by name
-      const sketchNames = ['Sketch1', 'Sketch2', 'Sketch3', 'Sketch4', 'Sketch5'];
-      for (const name of sketchNames) {
-        try {
-          const ext = this.currentModel.Extension;
-          if (ext) {
-            const selected = ext.SelectByID2(name, 'SKETCH', 0, 0, 0, false, 0, null, 0);
-            if (selected) {
+      // Method 1: Try to find sketch via feature tree traversal (most reliable)
+      try {
+        const featureCount = this.currentModel.GetFeatureCount();
+        logger.info(`Searching ${featureCount} features for sketch...`);
+
+        for (let i = 0; i < Math.min(10, featureCount); i++) {
+          const feat = this.currentModel.FeatureByPositionReverse(i);
+          if (feat) {
+            const typeName = feat.GetTypeName2();
+            const featName = feat.Name || feat.GetName();
+
+            if (typeName && (typeName === 'ProfileFeature' || typeName.toLowerCase().includes('sketch'))) {
+              feat.Select2(false, 0);
               sketchSelected = true;
-              selectedSketchName = name;
-              logger.info(`Selected sketch: ${name}`);
+              selectedSketchName = featName || `Feature at position ${i}`;
+              logger.info(`Selected sketch by feature tree: ${selectedSketchName}`);
               break;
-            } else {
-              attemptedSketches.push(name);
             }
           }
-        } catch (e) {
-          attemptedSketches.push(`${name} (error: ${e})`);
         }
+      } catch (e) {
+        logger.warn(`Feature tree search failed: ${e}`);
       }
 
-      // Method 2: Try to select the last feature if it's a sketch
+      // Method 2: Try to select by name using SelectByID2
+      // Note: Callout parameter must be undefined (not null) to avoid COM VT_NULL type mismatch
       if (!sketchSelected) {
-        try {
-          const featureCount = this.currentModel.GetFeatureCount();
-          logger.info(`Searching ${featureCount} features for sketch...`);
-
-          for (let i = 0; i < Math.min(10, featureCount); i++) {
-            const feat = this.currentModel.FeatureByPositionReverse(i);
-            if (feat) {
-              const typeName = feat.GetTypeName2();
-              const featName = feat.Name || feat.GetName();
-
-              if (typeName && typeName.toLowerCase().includes('sketch')) {
-                feat.Select2(false, 0);
+        const sketchNames = ['Sketch1', 'Sketch2', 'Sketch3', 'Sketch4', 'Sketch5'];
+        for (const name of sketchNames) {
+          try {
+            const ext = this.currentModel.Extension;
+            if (ext) {
+              const selected = ext.SelectByID2(name, 'SKETCH', 0, 0, 0, false, 0, undefined, 0);
+              if (selected) {
                 sketchSelected = true;
-                selectedSketchName = featName || `Feature at position ${i}`;
-                logger.info(`Selected sketch by position: ${selectedSketchName}`);
+                selectedSketchName = name;
+                logger.info(`Selected sketch: ${name}`);
                 break;
+              } else {
+                attemptedSketches.push(name);
               }
             }
+          } catch (e) {
+            attemptedSketches.push(`${name} (error: ${e})`);
           }
-        } catch (e) {
-          logger.warn(`Feature search failed: ${e}`);
         }
       }
 
@@ -451,7 +452,7 @@ export class SolidWorksAPI {
     // Method 4: Try SelectByID and get dimension
     if (!dimension) {
       try {
-        const selected = this.currentModel.Extension.SelectByID2(name, "DIMENSION", 0, 0, 0, false, 0, null, 0);
+        const selected = this.currentModel.Extension.SelectByID2(name, "DIMENSION", 0, 0, 0, false, 0, undefined, 0);
         if (selected) {
           const selMgr = this.currentModel.SelectionManager;
           if (selMgr && selMgr.GetSelectedObjectCount() > 0) {
@@ -466,11 +467,11 @@ export class SolidWorksAPI {
         // Selection method failed
       }
     }
-    
+
     if (!dimension) {
       throw new Error(`Dimension "${name}" not found. Try format like "D1@Sketch1" or "D1@Boss-Extrude1"`);
     }
-    
+
     // Get the value - try different properties
     let value = 0;
     try {
@@ -486,22 +487,22 @@ export class SolidWorksAPI {
     } catch (e) {
       throw new Error(`Cannot read value of dimension "${name}"`);
     }
-    
+
     return value;
   }
-  
+
   setDimension(name: string, value: number): void {
     if (!this.currentModel) throw new Error('No model open');
-    
+
     let dimension = null;
-    
+
     // Method 1: Try Parameter method
     try {
       dimension = this.currentModel.Parameter(name);
     } catch (e) {
       // Parameter might not work
     }
-    
+
     // Method 2: Try GetParameter
     if (!dimension) {
       try {
@@ -510,7 +511,7 @@ export class SolidWorksAPI {
         // GetParameter might not work
       }
     }
-    
+
     // Method 3: Try Extension.GetParameter
     if (!dimension) {
       try {
@@ -522,11 +523,11 @@ export class SolidWorksAPI {
         // Extension method might not work
       }
     }
-    
+
     // Method 4: Try SelectByID and get dimension
     if (!dimension) {
       try {
-        const selected = this.currentModel.Extension.SelectByID2(name, "DIMENSION", 0, 0, 0, false, 0, null, 0);
+        const selected = this.currentModel.Extension.SelectByID2(name, "DIMENSION", 0, 0, 0, false, 0, undefined, 0);
         if (selected) {
           const selMgr = this.currentModel.SelectionManager;
           if (selMgr && selMgr.GetSelectedObjectCount() > 0) {
@@ -625,7 +626,7 @@ export class SolidWorksAPI {
             success = this.currentModel.SaveAs3(filePath, 0, 2);
             if (!success) {
               // Method 2: Try Extension.SaveAs with swSaveAsCurrentVersion flag
-              success = this.currentModel.Extension.SaveAs(filePath, 0, 2, null, errors, warnings);
+              success = this.currentModel.Extension.SaveAs(filePath, 0, 2, undefined, errors, warnings);
             }
           } catch (e) {
             // Method 3: Try GetExportFileData approach
@@ -648,7 +649,7 @@ export class SolidWorksAPI {
             success = this.currentModel.SaveAs3(filePath, 0, 2);
             if (!success) {
               // Method 2: Try Extension.SaveAs
-              success = this.currentModel.Extension.SaveAs(filePath, 0, 2, null, errors, warnings);
+              success = this.currentModel.Extension.SaveAs(filePath, 0, 2, undefined, errors, warnings);
             }
           } catch (e) {
             throw new Error(`Failed to export to IGES: ${e}`);
@@ -666,7 +667,7 @@ export class SolidWorksAPI {
                 success = this.currentModel.SaveAs4(filePath, 0, 2, errors, warnings);
               } catch (e2) {
                 // Method 3: Try Extension.SaveAs
-                success = this.currentModel.Extension.SaveAs(filePath, 0, 2, null, errors, warnings);
+                success = this.currentModel.Extension.SaveAs(filePath, 0, 2, undefined, errors, warnings);
               }
             }
           } catch (e) {
@@ -683,7 +684,7 @@ export class SolidWorksAPI {
           try {
             success = this.currentModel.SaveAs3(filePath, 0, 2);
             if (!success) {
-              success = this.currentModel.Extension.SaveAs(filePath, 0, 2, null, errors, warnings);
+              success = this.currentModel.Extension.SaveAs(filePath, 0, 2, undefined, errors, warnings);
             }
           } catch (e) {
             throw new Error(`Failed to export to PDF: ${e}`);
@@ -696,7 +697,7 @@ export class SolidWorksAPI {
           try {
             success = this.currentModel.SaveAs3(filePath, 0, 2);
             if (!success) {
-              success = this.currentModel.Extension.SaveAs(filePath, 0, 2, null, errors, warnings);
+              success = this.currentModel.Extension.SaveAs(filePath, 0, 2, undefined, errors, warnings);
             }
           } catch (e) {
             throw new Error(`Failed to export to ${format.toUpperCase()}: ${e}`);

--- a/src/tools/export.ts
+++ b/src/tools/export.ts
@@ -153,7 +153,7 @@ export const exportTools = [
               // 0x00000020 = swSaveAsOptions_SaveAsPNG
               // 0x00000040 = swSaveAsOptions_SaveAsJPEG
               const formatFlag = ext === 'png' ? 0x20 : 0x40;
-              success = model.Extension.SaveAs2(args.outputPath, 0, formatFlag, null, null, false, null);
+              success = model.Extension.SaveAs2(args.outputPath, 0, formatFlag, undefined, undefined, false, undefined);
             } else {
               // Fallback to SaveBMP and note format limitation
               success = model.SaveBMP(args.outputPath, args.width || 1920, args.height || 1080);

--- a/src/tools/extrusion-helper.ts
+++ b/src/tools/extrusion-helper.ts
@@ -21,18 +21,39 @@ export const extrusionHelper = {
       // Clear selections
       model.ClearSelection2(true);
       
-      // Select the sketch using a simpler approach
+      // Select the sketch - try feature tree first, then SelectByID2
       let sketchFound = false;
-      const sketchNames = ['Sketch1', 'Sketch2', 'Sketch3'];
-      
-      for (const name of sketchNames) {
-        try {
-          if (ext.SelectByID2(name, 'SKETCH', 0, 0, 0, false, 4, null, 0)) {
-            sketchFound = true;
-            break;
+
+      // Method 1: Feature tree traversal (most reliable)
+      try {
+        const featureCount = model.GetFeatureCount();
+        for (let i = 0; i < Math.min(10, featureCount); i++) {
+          const feat = model.FeatureByPositionReverse(i);
+          if (feat) {
+            const typeName = feat.GetTypeName2();
+            if (typeName && (typeName === 'ProfileFeature' || typeName.toLowerCase().includes('sketch'))) {
+              feat.Select2(false, 4);
+              sketchFound = true;
+              break;
+            }
           }
-        } catch (e) {
-          continue;
+        }
+      } catch (e) {
+        // Fall through to SelectByID2
+      }
+
+      // Method 2: SelectByID2 with undefined Callout (not null, avoids VT_NULL type mismatch)
+      if (!sketchFound) {
+        const sketchNames = ['Sketch1', 'Sketch2', 'Sketch3'];
+        for (const name of sketchNames) {
+          try {
+            if (ext.SelectByID2(name, 'SKETCH', 0, 0, 0, false, 4, undefined, 0)) {
+              sketchFound = true;
+              break;
+            }
+          } catch (e) {
+            continue;
+          }
         }
       }
       

--- a/src/tools/sketch.ts
+++ b/src/tools/sketch.ts
@@ -147,7 +147,7 @@ export const sketchTools = [
         if (!model) throw new Error('No active model');
         
         // Select the sketch
-        const selected = model.Extension.SelectByID2(args.sketchName, 'SKETCH', 0, 0, 0, false, 0, null, 0);
+        const selected = model.Extension.SelectByID2(args.sketchName, 'SKETCH', 0, 0, 0, false, 0, undefined, 0);
         if (!selected) throw new Error('Sketch not found');
         
         // Edit sketch
@@ -695,14 +695,14 @@ export const sketchTools = [
         
         // Select entities
         model.ClearSelection2(true);
-        model.Extension.SelectByID2(args.entity1, 'SKETCHSEGMENT', 0, 0, 0, false, 0, null, 0);
+        model.Extension.SelectByID2(args.entity1, 'SKETCHSEGMENT', 0, 0, 0, false, 0, undefined, 0);
         
         if (args.entity2) {
-          model.Extension.SelectByID2(args.entity2, 'SKETCHSEGMENT', 0, 0, 0, true, 0, null, 0);
+          model.Extension.SelectByID2(args.entity2, 'SKETCHSEGMENT', 0, 0, 0, true, 0, undefined, 0);
         }
         
         if (args.entity3) {
-          model.Extension.SelectByID2(args.entity3, 'SKETCHSEGMENT', 0, 0, 0, true, 0, null, 0);
+          model.Extension.SelectByID2(args.entity3, 'SKETCHSEGMENT', 0, 0, 0, true, 0, undefined, 0);
         }
         
         // Add constraint
@@ -744,7 +744,7 @@ export const sketchTools = [
         
         // Select entity
         model.ClearSelection2(true);
-        model.Extension.SelectByID2(args.entity, 'SKETCHSEGMENT', 0, 0, 0, false, 0, null, 0);
+        model.Extension.SelectByID2(args.entity, 'SKETCHSEGMENT', 0, 0, 0, false, 0, undefined, 0);
         
         // Add dimension
         const textX = args.position?.x || 0;
@@ -815,7 +815,7 @@ export const sketchTools = [
         // Select entities to pattern
         model.ClearSelection2(true);
         args.entities.forEach((entity: string) => {
-          model.Extension.SelectByID2(entity, 'SKETCHSEGMENT', 0, 0, 0, true, 0, null, 0);
+          model.Extension.SelectByID2(entity, 'SKETCHSEGMENT', 0, 0, 0, true, 0, undefined, 0);
         });
         
         // Create pattern
@@ -857,7 +857,7 @@ export const sketchTools = [
         // Select entities to pattern
         model.ClearSelection2(true);
         args.entities.forEach((entity: string) => {
-          model.Extension.SelectByID2(entity, 'SKETCHSEGMENT', 0, 0, 0, true, 0, null, 0);
+          model.Extension.SelectByID2(entity, 'SKETCHSEGMENT', 0, 0, 0, true, 0, undefined, 0);
         });
         
         // Calculate angular spacing
@@ -898,11 +898,11 @@ export const sketchTools = [
         // Select entities to mirror
         model.ClearSelection2(true);
         args.entities.forEach((entity: string) => {
-          model.Extension.SelectByID2(entity, 'SKETCHSEGMENT', 0, 0, 0, true, 0, null, 0);
+          model.Extension.SelectByID2(entity, 'SKETCHSEGMENT', 0, 0, 0, true, 0, undefined, 0);
         });
         
         // Select mirror line
-        model.Extension.SelectByID2(args.mirrorLine, 'SKETCHSEGMENT', 0, 0, 0, true, 1, null, 0);
+        model.Extension.SelectByID2(args.mirrorLine, 'SKETCHSEGMENT', 0, 0, 0, true, 1, undefined, 0);
         
         // Mirror entities
         model.SketchManager.MirrorSketch();
@@ -937,7 +937,7 @@ export const sketchTools = [
         // Select entities to offset
         model.ClearSelection2(true);
         args.entities.forEach((entity: string) => {
-          model.Extension.SelectByID2(entity, 'SKETCHSEGMENT', 0, 0, 0, true, 0, null, 0);
+          model.Extension.SelectByID2(entity, 'SKETCHSEGMENT', 0, 0, 0, true, 0, undefined, 0);
         });
         
         // Create offset


### PR DESCRIPTION
## Summary
This PR fixes COM interop compatibility issues across the SolidWorks API integration by replacing `null` with `undefined` for optional parameters in `SelectByID2` and `SaveAs` method calls. This resolves VT_NULL type mismatch errors that occur when passing null values to COM methods expecting optional parameters.

## Key Changes

- **SelectByID2 Callout parameter**: Changed all `null` to `undefined` in the 8th parameter (Callout) across multiple files. The COM interface expects `undefined` for optional parameters rather than `null`, which causes type mismatch errors.

- **SaveAs methods**: Updated `SaveAs`, `SaveAs2`, and `SaveAs3` calls to use `undefined` instead of `null` for optional parameters.

- **Sketch selection strategy reordering**: Reorganized sketch selection logic to prioritize feature tree traversal (using `FeatureByPositionReverse` and `GetTypeName2`) as the primary method before falling back to `SelectByID2`. This approach is more reliable and avoids COM selection issues.
  - Method 1: Feature tree traversal with ProfileFeature/sketch type checking
  - Method 2: SelectByID2 with corrected `undefined` parameter

- **Enhanced type checking**: Improved sketch detection to check for both `'ProfileFeature'` type name and sketch-containing strings, making the selection more robust.

- **Code cleanup**: Fixed trailing whitespace and formatting inconsistencies throughout the affected files.

## Files Modified
- `src/solidworks/api.ts` - Core API sketch selection and dimension/export methods
- `src/adapters/winax-adapter.ts` - WinAX adapter sketch selection
- `src/adapters/winax-adapter-enhanced.ts` - Enhanced adapter sketch selection
- `src/tools/extrusion-helper.ts` - Extrusion helper sketch selection
- `src/tools/sketch.ts` - Sketch tool SelectByID2 calls
- `src/tools/export.ts` - Export tool SaveAs calls

## Implementation Details
The change from `null` to `undefined` is critical for COM interop because:
- COM methods with optional parameters expect `undefined` (JavaScript's "no value" representation)
- Passing `null` creates a VT_NULL variant type, which COM methods don't recognize as "optional parameter not provided"
- This causes type mismatch errors in the COM layer

The feature tree traversal approach is more reliable because it directly accesses the model's feature collection rather than relying on the COM selection manager, which can be finicky with certain object types.

https://claude.ai/code/session_01PaEPTu8vwm8Za9BRKJws7f