### PR TITLE
Fix create_extrusion COM type mismatch with VBA macro fallback

### DIFF
--- a/src/adapters/macro-generator.ts
+++ b/src/adapters/macro-generator.ts
@@ -50,7 +50,7 @@ Sub CreateExtrusion()
     Set swModel = swApp.ActiveDoc
 
     If swModel Is Nothing Then
-        MsgBox "ERROR: No active document", vbCritical, "Extrusion Macro"
+        Debug.Print "ERROR: No active document"
         Exit Sub
     End If
 
@@ -159,18 +159,17 @@ Sub CreateExtrusion()
 
     ' Check if feature was created successfully
     If swFeature Is Nothing Then
-        MsgBox "ERROR: Extrusion feature was not created. Check that a valid sketch is selected.", vbCritical, "Extrusion Macro"
+        Debug.Print "ERROR: Extrusion feature was not created. Check that a valid sketch is selected."
         Exit Sub
     End If
 
-    MsgBox "Extrusion created successfully: " & swFeature.Name, vbInformation, "Extrusion Macro"
+    Debug.Print "Extrusion created successfully: " & swFeature.Name
     Exit Sub
 
 ErrorHandler:
     If errorMsg = "" Then
         errorMsg = "Unexpected error: " & Err.Description & " (Error " & Err.Number & ")"
     End If
-    MsgBox errorMsg, vbCritical, "Extrusion Macro Error"
     Debug.Print errorMsg
 End Sub
 
@@ -209,7 +208,7 @@ Sub CreateRevolve()
     Set swModel = swApp.ActiveDoc
 
     If swModel Is Nothing Then
-        MsgBox "ERROR: No active document", vbCritical, "Revolve Macro"
+        Debug.Print "ERROR: No active document"
         Exit Sub
     End If
 
@@ -282,18 +281,18 @@ Sub CreateRevolve()
 
     ' Check if feature was created successfully
     If swFeature Is Nothing Then
-        MsgBox "ERROR: Revolve feature was not created. Check sketch and axis selection.", vbCritical, "Revolve Macro"
+        Debug.Print "ERROR: Revolve feature was not created. Check sketch and axis selection."
         Exit Sub
     End If
 
-    MsgBox "Revolve created successfully: " & swFeature.Name, vbInformation, "Revolve Macro"
+    Debug.Print "Revolve created successfully: " & swFeature.Name
     Exit Sub
 
 ErrorHandler:
     If errorMsg = "" Then
         errorMsg = "Unexpected error: " & Err.Description & " (Error " & Err.Number & ")"
     End If
-    MsgBox errorMsg, vbCritical, "Revolve Macro Error"
+    Debug.Print "Revolve error: " & errorMsg
     Debug.Print errorMsg
 End Sub
 
@@ -352,7 +351,7 @@ Sub CreateSweep()
     Set swModel = swApp.ActiveDoc
     
     If swModel Is Nothing Then
-        MsgBox "No active document"
+        Debug.Print "No active document"
         Exit Sub
     End If
     
@@ -442,7 +441,7 @@ Sub CreateLoft()
     Set swModel = swApp.ActiveDoc
     
     If swModel Is Nothing Then
-        MsgBox "No active document"
+        Debug.Print "No active document"
         Exit Sub
     End If
     
@@ -517,7 +516,7 @@ Sub Execute${methodName}()
     Set swModel = swApp.ActiveDoc
 
     If swModel Is Nothing Then
-        MsgBox "ERROR: No active document", vbCritical, "Macro Execution"
+        Debug.Print "ERROR: No active document"
         Exit Sub
     End If
 
@@ -529,16 +528,16 @@ Sub Execute${methodName}()
 
     ' Check result
     If IsEmpty(result) Or result = False Or result Is Nothing Then
-        MsgBox "WARNING: Method ${methodName} returned no result or failed", vbExclamation, "Macro Execution"
+        Debug.Print "WARNING: Method ${methodName} returned no result or failed"
     Else
-        MsgBox "Method ${methodName} executed successfully", vbInformation, "Macro Execution"
+        Debug.Print "Method ${methodName} executed successfully"
     End If
 
     Exit Sub
 
 ErrorHandler:
     errorMsg = "ERROR executing ${methodName}: " & Err.Description & " (Error " & Err.Number & ")"
-    MsgBox errorMsg, vbCritical, "Macro Execution Error"
+    Debug.Print "Macro error: " & errorMsg
     Debug.Print errorMsg
 End Sub
 `;

--- a/src/solidworks/api.ts
+++ b/src/solidworks/api.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 // @ts-ignore
 import winax from 'winax';
 import { logger } from '../utils/logger.js';
@@ -399,10 +402,11 @@ export class SolidWorksAPI {
               logger.info('FeatureExtrusion succeeded with standard call');
             }
           } catch (e3) {
-            logger.error(`All extrusion methods failed: ${e3}`);
-            throw new Error(
-              `Extrusion failed due to COM interface limitations. Consider using a VBA macro approach for complex extrusions. Details: ${e3}`
-            );
+            logger.warn(`All direct COM extrusion methods failed: ${e3}`);
+            logger.info('Falling back to VBA macro execution for extrusion...');
+
+            // Method 4: VBA macro fallback - bypasses winax parameter limit
+            feature = this.executeExtrusionViaMacro(depthInMeters, reverse);
           }
         }
       }
@@ -448,6 +452,116 @@ export class SolidWorksAPI {
       };
     } catch (error) {
       throw new Error(`Extrusion failed: ${error}`);
+    }
+  }
+
+  /**
+   * Execute extrusion via VBA macro - bypasses winax COM parameter limit.
+   * Used as fallback when direct COM calls fail with type mismatch errors.
+   */
+  private executeExtrusionViaMacro(depthInMeters: number, reverse: boolean): any {
+    const macroDir = join(tmpdir(), 'solidworks-mcp-macros');
+    const macroPath = join(macroDir, `extrusion_${Date.now()}.swp`);
+
+    try {
+      mkdirSync(macroDir, { recursive: true });
+    } catch (_e) {
+      // Directory may already exist
+    }
+
+    // Generate a silent VBA macro (no MsgBox — automation-safe)
+    const vbaCode = `Attribute VB_Name = "Module1"
+Option Explicit
+
+Sub CreateExtrusion()
+    Dim swApp As Object
+    Dim swModel As Object
+    Dim swFeatureMgr As Object
+    Dim swFeature As Object
+
+    On Error GoTo ErrorHandler
+
+    Set swApp = Application.SldWorks
+    Set swModel = swApp.ActiveDoc
+
+    If swModel Is Nothing Then Exit Sub
+
+    Set swFeatureMgr = swModel.FeatureManager
+
+    ' The sketch should already be selected by the caller.
+    ' Create a simple blind extrusion using FeatureExtrusion3
+    Set swFeature = swFeatureMgr.FeatureExtrusion3( _
+        True, _              ' Sd  (single direction)
+        ${reverse ? 'True' : 'False'}, _             ' Flip
+        False, _             ' Dir (both directions)
+        0, _                 ' T1  (blind end condition)
+        0, _                 ' T2
+        ${depthInMeters}, _  ' D1  (depth in meters)
+        0, _                 ' D2
+        False, _             ' Dchk1 (draft while extruding)
+        False, _             ' Dchk2
+        False, _             ' Ddir1 (draft outward)
+        False, _             ' Ddir2
+        0, _                 ' Dang1 (draft angle)
+        0, _                 ' Dang2
+        False, _             ' OffsetReverse1
+        False, _             ' OffsetReverse2
+        False, _             ' TranslateSurface1
+        False, _             ' TranslateSurface2
+        True, _              ' Merge
+        False, _             ' FlipSideToCut
+        True, _              ' UseFeatScope
+        0, _                 ' StartCondition
+        0, _                 ' StartOffset
+        False _              ' FlipStartOffset
+    )
+
+    ' Rebuild the model
+    swModel.EditRebuild3
+
+    Exit Sub
+
+ErrorHandler:
+    ' Silent fail — caller checks for feature creation
+    Debug.Print "Extrusion macro error: " & Err.Description
+End Sub
+`;
+
+    try {
+      writeFileSync(macroPath, vbaCode, 'utf-8');
+      logger.info(`Wrote extrusion macro to ${macroPath}`);
+
+      // Execute the macro via SolidWorks RunMacro2
+      const runResult = this.swApp.RunMacro2(
+        macroPath,
+        'Module1',
+        'CreateExtrusion',
+        1, // swRunMacroOption_e.swRunMacroUnloadAfterRun
+        0 // error out param
+      );
+      logger.info(`RunMacro2 returned: ${runResult}`);
+
+      // Retrieve the newly created feature (should be the most recent)
+      const feature = this.currentModel.FeatureByPositionReverse(0);
+      if (feature) {
+        const typeName = feature.GetTypeName2?.() || '';
+        if (typeName.toLowerCase().includes('extrusion') || typeName.toLowerCase().includes('boss')) {
+          logger.info(`VBA macro extrusion succeeded: ${feature.Name || feature.GetName?.()}`);
+          return feature;
+        }
+      }
+
+      throw new Error('VBA macro executed but no extrusion feature found');
+    } catch (macroError) {
+      logger.error(`VBA macro extrusion failed: ${macroError}`);
+      throw new Error(`Extrusion failed: all direct COM methods and VBA macro fallback failed. Details: ${macroError}`);
+    } finally {
+      // Clean up temp macro file
+      try {
+        unlinkSync(macroPath);
+      } catch (_e) {
+        // Ignore cleanup errors
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds VBA macro fallback (Method 4) to `createExtrude` when all direct COM calls fail due to winax's ~12 parameter limit on `FeatureExtrusion` (13 params)
- The macro is generated at runtime, written to a temp `.swp` file, executed via `RunMacro2`, then cleaned up
- Replaces all `MsgBox` calls in generated VBA macros with `Debug.Print` to prevent dialog popups from blocking MCP automation

Closes #16

## Root Cause
The winax COM bridge has a practical limit of ~12 parameters per method call. `FeatureExtrusion` requires 13, causing a `DispInvoke: FeatureExtrusion 类型不匹配` (type mismatch) error. The existing code tried 3 different COM calling conventions (`.apply()`, `__methods__`, `VARIANT` wrapper) but none bypass this fundamental limit.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 52/52 pass
- [x] `npm run check` — typecheck + Biome clean
- [ ] Manual test on Windows with SolidWorks: create a sketch, then call `create_extrusion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)