### PR TITLE
Fix #21: add missing @ts-ignore on winax import in enhanced adapter

### DIFF
--- a/src/adapters/winax-adapter-enhanced.ts
+++ b/src/adapters/winax-adapter-enhanced.ts
@@ -7,6 +7,7 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+// @ts-ignore
 import winax from 'winax';
 import type { SolidWorksFeature, SolidWorksModel } from '../solidworks/types.js';
 import { logger } from '../utils/logger.js';


### PR DESCRIPTION
## Summary
- Fixes #21 (build failure: `TS2307: Cannot find module 'winax'`)
- Adds the missing `// @ts-ignore` pragma to the winax import in `src/adapters/winax-adapter-enhanced.ts`, bringing it in line with every other winax import in the codebase (see `winax-adapter.ts:13`, `solidworks/api.ts:4`).
- CLAUDE.md already documents this as the intentional convention: winax has no bundled type definitions we can rely on across versions, so the import must be suppressed to keep `tsc` working when the optional dependency fails to resolve on the user's machine.

## Test plan
- [x] `npm run build` — clean compile
- [x] `npm test` — 52/52 tests passing
- [ ] Confirm reporter's `npm install && npm run build` succeeds on Windows after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)