### PR TITLE
Fix #23: lazy-load winax so missing native module no longer crashes the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ Key areas where help is needed:
 
 ## Troubleshooting
 
+For `winax` native build failures on Windows 11 Build 26200+ / VS 2022
+BuildTools 17.14+ (issue #23) and other install-time problems, see
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+
 ### COM Registration Issues
 ```powershell
 regsvr32 "C:\Program Files\SOLIDWORKS Corp\SOLIDWORKS\sldworks.tlb"

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,132 @@
+# Troubleshooting
+
+Common problems when installing or running the SolidWorks MCP Server.
+
+---
+
+## `winax` build fails on Windows 11 (VS 2022 BuildTools 17.14+)
+
+### Symptom
+
+`npm install` appears to succeed but `node dist/index.js` exits immediately with:
+
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'winax' imported from …\dist\solidworks\api.js
+```
+
+Forcing a build (`npm install winax --save --foreground-scripts`) reveals C++
+compile errors inside `winax/src/utils.h` and `winax/src/disp.h`, most involving
+`CComVariant`:
+
+```
+error C3203: 'CComVariant': unspecialized class template can't be used as a
+             template argument for template parameter '_Ty'
+error C2665: 'DispInvoke': no overloaded function could convert all the argument types
+error C2512: 'CComVariant': no appropriate default constructor available
+```
+
+### Cause
+
+This is an **upstream `winax` incompatibility** with recent Windows SDK / ATL
+headers shipped with Visual Studio 2022 Build Tools 17.14+ (typically seen on
+Windows 11 Build 26200+). The ATL headers changed `CComVariant`'s declaration
+in ways the current `winax` native sources don't account for. See
+[issue #23](https://github.com/vespo92/SolidworksMCP-TS/issues/23).
+
+Because `winax` is declared as an `optionalDependency`, npm hides the compile
+failure — the package is silently skipped, and the server then crashes at
+first-import.
+
+### Fixes, in order of preference
+
+#### 1. Develop against the mock adapter (no SolidWorks required)
+
+For everything that isn't COM automation itself — tool development, schema
+work, MCP wiring — set:
+
+```powershell
+$env:USE_MOCK_SOLIDWORKS = "true"
+npm run build
+node dist/index.js
+```
+
+The mock adapter (`src/adapters/mock-solidworks-adapter.ts`) satisfies the
+same interface and is what the test suite uses.
+
+#### 2. Pin an older `winax` release
+
+Versions before the ATL-header incompatibility may still compile. Try:
+
+```powershell
+npm install winax@3.4.2 --save-optional --foreground-scripts
+npm run build
+```
+
+If 3.4.2 also fails, step down further (3.3.x) and report which version works
+on your toolchain.
+
+> These versions have not been validated against the current MCP server, so
+> please run `npm test` afterwards and flag any regressions on issue #23.
+
+#### 3. Install an older VS 2022 Build Tools
+
+If you can control your toolchain, installing VS 2022 Build Tools **17.10 or
+earlier** (with the "Desktop development with C++" workload and the "C++ ATL
+for latest v143 build tools (x86 & x64)" component) avoids the incompatible
+ATL headers. Set `GYP_MSVS_VERSION=2022` and reinstall.
+
+#### 4. Wait for upstream fix
+
+Track [winax on GitHub](https://github.com/durs/node-activex) and node-gyp
+issue [#3251](https://github.com/nodejs/node-gyp/issues/3251). Once `winax`
+ships an ATL-compatible release, update your lockfile.
+
+---
+
+## Graceful degradation
+
+As of the PR that added this doc, the server no longer hard-crashes when
+`winax` is missing. Any code path that actually needs COM automation will
+throw a descriptive error like:
+
+```
+The `winax` native module is not available. SolidWorks COM automation requires it on Windows.
+
+Common causes:
+  • Build failure on Windows 11 (Build 26200+) with VS 2022 BuildTools 17.14+
+    (upstream winax/ATL CComVariant incompatibility — see issue #23).
+  • Installing on a non-Windows platform (winax is Windows-only).
+  • `npm install --ignore-scripts` skipped the native build step.
+
+Workarounds:
+  • For development without real SolidWorks, set USE_MOCK_SOLIDWORKS=true.
+  • Try pinning an older winax release: `npm i winax@3.4.2` and rebuild.
+  • See TROUBLESHOOTING.md in the repository root for the full recovery guide.
+
+Underlying load error: …
+```
+
+The rest of the server (tool registration, mock adapter, macro generation,
+VBA tools, resources) continues to work.
+
+---
+
+## Non-Windows development
+
+`winax` is Windows-only. On macOS and Linux, install with
+`npm install --ignore-scripts` (or rely on `optionalDependencies` silently
+skipping it). Then always run with `USE_MOCK_SOLIDWORKS=true`.
+
+---
+
+## Reporting a new failure
+
+Please open an issue with:
+
+- Windows build number (`winver`)
+- Node version (`node -v`)
+- VS Build Tools version (Visual Studio Installer → Modify)
+- `npm install winax --foreground-scripts` log
+- `npm ls winax` output
+
+This helps us correlate failure signatures to specific toolchain versions.

--- a/src/adapters/factory.ts
+++ b/src/adapters/factory.ts
@@ -13,6 +13,7 @@ import { CircuitBreakerAdapter } from './circuit-breaker.js';
 import { ConnectionPoolAdapter } from './connection-pool.js';
 import type { AdapterConfig, AdapterHealth, ISolidWorksAdapter } from './types.js';
 import { WinAxAdapter } from './winax-adapter.js';
+import { isWinaxAvailable } from './winax-loader.js';
 
 /**
  * Factory for creating and managing SolidWorks adapters
@@ -162,13 +163,9 @@ export class AdapterFactory {
       osType: process.platform,
     };
 
-    // Check for winax availability
-    try {
-      require('winax');
-      capabilities.hasWinAx = true;
-    } catch (_e) {
-      capabilities.hasWinAx = false;
-    }
+    // Check for winax availability (uses the shared lazy loader so the probe
+    // result is cached alongside real adapter loads).
+    capabilities.hasWinAx = isWinaxAvailable();
 
     // Get system memory
     try {

--- a/src/adapters/winax-adapter-enhanced.ts
+++ b/src/adapters/winax-adapter-enhanced.ts
@@ -7,8 +7,6 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-// @ts-ignore
-import winax from 'winax';
 import type { SolidWorksFeature, SolidWorksModel } from '../solidworks/types.js';
 import { logger } from '../utils/logger.js';
 import { FeatureComplexityAnalyzer } from './feature-complexity-analyzer.js';
@@ -24,6 +22,9 @@ import type {
   RevolveParameters,
   SweepParameters,
 } from './types.js';
+import { loadWinax } from './winax-loader.js';
+
+let winax: any = null;
 
 export class EnhancedWinAxAdapter implements ISolidWorksAdapter {
   private swApp: any;
@@ -47,6 +48,7 @@ export class EnhancedWinAxAdapter implements ISolidWorksAdapter {
   // Connection Management
   async connect(): Promise<void> {
     try {
+      if (!winax) winax = loadWinax();
       this.swApp = new winax.Object('SldWorks.Application');
       this.swApp.Visible = true;
       logger.info('Connected to SolidWorks via Enhanced WinAx adapter');

--- a/src/adapters/winax-adapter.ts
+++ b/src/adapters/winax-adapter.ts
@@ -10,8 +10,6 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-// @ts-ignore
-import winax from 'winax';
 import type { SolidWorksFeature, SolidWorksModel } from '../solidworks/types.js';
 import { logger } from '../utils/logger.js';
 import { MacroGenerator } from './macro-generator.js';
@@ -26,6 +24,9 @@ import type {
   RevolveParameters,
   SweepParameters,
 } from './types.js';
+import { loadWinax } from './winax-loader.js';
+
+let winax: any = null;
 
 export class WinAxAdapter implements ISolidWorksAdapter {
   private swApp: any = null;
@@ -50,13 +51,13 @@ export class WinAxAdapter implements ISolidWorksAdapter {
       // Ensure temp macro directory exists
       await fs.mkdir(this.tempMacroPath, { recursive: true });
 
+      if (!winax) winax = loadWinax();
+
       // Try primary connection method
       try {
-        // @ts-ignore
         this.swApp = new winax.Object('SldWorks.Application');
       } catch (_error) {
         // Try alternative connection method
-        // @ts-ignore
         this.swApp = winax.Object('SldWorks.Application');
       }
 

--- a/src/adapters/winax-loader.ts
+++ b/src/adapters/winax-loader.ts
@@ -1,0 +1,74 @@
+/**
+ * Lazy loader for the `winax` optional native dependency.
+ *
+ * `winax` ships as an optionalDependency because it only builds on Windows and
+ * can fail on newer toolchains (e.g. Windows 11 Build 26200+ with VS 2022
+ * BuildTools 17.14+, see issue #23). Importing it at module load time would
+ * crash the whole server with ERR_MODULE_NOT_FOUND whenever the build was
+ * skipped. Loading it lazily lets non-winax code paths (mock adapter, docs,
+ * macro generation) keep working and lets us surface an actionable error
+ * message when real COM automation is actually requested.
+ */
+
+import { createRequire } from 'node:module';
+
+const nodeRequire = createRequire(import.meta.url);
+
+let cachedWinax: any = null;
+let loadError: Error | null = null;
+
+/**
+ * Returns the `winax` module. Throws an actionable error if it is missing or
+ * failed to build. The result is cached — the underlying require runs at most
+ * once per process (success or failure).
+ */
+export function loadWinax(): any {
+  if (cachedWinax) return cachedWinax;
+  if (loadError) throw loadError;
+
+  try {
+    const mod = nodeRequire('winax');
+    cachedWinax = mod && typeof mod === 'object' && 'default' in mod ? (mod as any).default : mod;
+    return cachedWinax;
+  } catch (err) {
+    loadError = new Error(buildWinaxErrorMessage(err));
+    throw loadError;
+  }
+}
+
+/**
+ * Non-throwing variant used for capability detection. Returns `null` if winax
+ * is unavailable for any reason.
+ */
+export function tryLoadWinax(): any | null {
+  try {
+    return loadWinax();
+  } catch {
+    return null;
+  }
+}
+
+/** True if winax can be loaded in this environment. */
+export function isWinaxAvailable(): boolean {
+  return tryLoadWinax() !== null;
+}
+
+function buildWinaxErrorMessage(err: unknown): string {
+  const underlying = err instanceof Error ? err.message : String(err);
+  return [
+    'The `winax` native module is not available. SolidWorks COM automation requires it on Windows.',
+    '',
+    'Common causes:',
+    '  • Build failure on Windows 11 (Build 26200+) with VS 2022 BuildTools 17.14+',
+    '    (upstream winax/ATL CComVariant incompatibility — see issue #23).',
+    '  • Installing on a non-Windows platform (winax is Windows-only).',
+    '  • `npm install --ignore-scripts` skipped the native build step.',
+    '',
+    'Workarounds:',
+    '  • For development without real SolidWorks, set USE_MOCK_SOLIDWORKS=true.',
+    '  • Try pinning an older winax release: `npm i winax@3.4.2` and rebuild.',
+    '  • See TROUBLESHOOTING.md in the repository root for the full recovery guide.',
+    '',
+    `Underlying load error: ${underlying}`,
+  ].join('\n');
+}

--- a/src/solidworks/api.ts
+++ b/src/solidworks/api.ts
@@ -1,10 +1,11 @@
 import { mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-// @ts-ignore
-import winax from 'winax';
+import { loadWinax } from '../adapters/winax-loader.js';
 import { logger } from '../utils/logger.js';
 import type { SolidWorksFeature, SolidWorksModel } from './types.js';
+
+let winax: any = null;
 
 export class SolidWorksAPI {
   private swApp: any;
@@ -16,16 +17,15 @@ export class SolidWorksAPI {
   }
 
   connect(): void {
+    if (!winax) winax = loadWinax();
     try {
       // Create or get running instance of SolidWorks
-      // @ts-ignore
       this.swApp = new winax.Object('SldWorks.Application');
       this.swApp.Visible = true;
       logger.info('Connected to SolidWorks');
     } catch (_error) {
       // Try alternative connection method
       try {
-        // @ts-ignore
         this.swApp = winax.Object('SldWorks.Application');
         this.swApp.Visible = true;
         logger.info('Connected to SolidWorks (alternative method)');


### PR DESCRIPTION
## Summary

Fixes #23.

`winax` is declared as an `optionalDependency` because it only builds on Windows and can fail on newer toolchains (most recently Win11 Build 26200+ with VS 2022 BuildTools 17.14+, where ATL's `CComVariant` changed shape). But three source files imported it at the top level, so a silently-skipped winax install caused `node dist/index.js` to hard-crash with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'winax'
```

This PR makes the server degrade gracefully instead:

- **`src/adapters/winax-loader.ts`** — new shared lazy loader with `loadWinax()`, `tryLoadWinax()`, `isWinaxAvailable()`. Caches result per process. On failure, throws an actionable error naming the Win11 / VS 17.14 scenario, pointing to `USE_MOCK_SOLIDWORKS=true`, the older-winax pin, and `TROUBLESHOOTING.md`.
- Top-level `import winax from 'winax'` statements in `src/solidworks/api.ts`, `src/adapters/winax-adapter.ts`, and `src/adapters/winax-adapter-enhanced.ts` converted to module-scoped vars populated on first `connect()`.
- `src/adapters/factory.ts` capability probe now calls `isWinaxAvailable()` instead of its own `require('winax')` try/catch.
- **`TROUBLESHOOTING.md`** — documents the VS 2022 17.14 / Build 26200 failure, mock-mode dev flow, and the older-winax pin workaround. Linked from README.

This PR does **not** attempt to pin a known-good winax version — that needs real Windows validation the reporter can help with. The docs make the try-older-winax workaround explicit.

## Behavior change

- **Before:** Missing winax → server crashes at import time with an unhelpful stack trace.
- **After:** Missing winax → server starts, mock adapter / macro tools / resource registry all work. Calling a real COM path throws a descriptive error with recovery steps.

## Test plan

- [x] `npm run check` (tsc + biome) clean
- [x] `npm test` — 52/52 pass on macOS (mock mode)
- [ ] Verify on Windows with winax installed: `connect()` still succeeds and creates the COM object on first call
- [ ] Verify on Windows *without* winax: server boots, `USE_MOCK_SOLIDWORKS=true` works, real COM call produces the new actionable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)